### PR TITLE
Fix issue with --exclude-dirs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ This will create a file named `output.txt` containing the inlined content of you
 - `--exclude-dirs`: Directories to exclude (optional, can specify multiple)
 - `--exclude-files`: Files to exclude (optional, can specify multiple)
 
+## Note
+
+The `--exclude-dirs` option should use relative paths from `project_dir`.

--- a/inline_project.py
+++ b/inline_project.py
@@ -7,9 +7,15 @@ def inline_project(project_dir, output_file, exclude_dirs=None, exclude_files=No
     if exclude_files is None:
         exclude_files = set()
 
+    exclude_dirs = {os.path.relpath(os.path.join(project_dir, d), project_dir) for d in exclude_dirs}
+
     with open(output_file, 'w', encoding='utf-8') as outfile:
         for root, dirs, files in os.walk(project_dir):
-            dirs[:] = [d for d in dirs if d not in exclude_dirs]
+            rel_root = os.path.relpath(root, project_dir)
+            if rel_root in exclude_dirs:
+                continue
+
+            dirs[:] = [d for d in dirs if os.path.relpath(os.path.join(root, d), project_dir) not in exclude_dirs]
             
             for file in files:
                 if file in exclude_files:


### PR DESCRIPTION
Fixes #2

Update `inline_project.py` to handle relative paths for `--exclude-dirs` option.

* Modify the `inline_project` function to convert `exclude_dirs` to relative paths.
* Add a check to skip directories that match the relative paths in `exclude_dirs`.
* Update the filtering of directories to use relative paths.

Update `README.md` to clarify the usage of `--exclude-dirs` option with relative paths.

* Add a note explaining that `--exclude-dirs` should use relative paths from `project_dir`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreibondarev/inline_project/issues/2?shareId=e361d1ac-15f9-423b-b2f0-39bbeac44d9f).